### PR TITLE
fix: move .env.example inline comment off the value line

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 MEMCLAW_API_KEY=mc_your_key_here
-MEMCLAW_TENANT_ID=your_tenant_id_here  # used by simulate.py for direct API calls (crystallizer) only — not by the MCP server
+# used by simulate.py for direct API calls (crystallizer) only — not by the MCP server
+MEMCLAW_TENANT_ID=your_tenant_id_here
 MEMCLAW_FLEET_ID=fleet-longrun-research
 LLM_GATEWAY_API_KEY=your_llm_key_here
 


### PR DESCRIPTION
## Summary
Inline comments after values in `.env` files are not stripped by python-dotenv and become part of the value.

## Changes
- Move the `MEMCLAW_TENANT_ID` note to its own comment line
- Ensure trailing newline

Closes #7